### PR TITLE
Add dynamic display functionallity

### DIFF
--- a/src/entities/Navbar/config/DOMAttributes.js
+++ b/src/entities/Navbar/config/DOMAttributes.js
@@ -11,5 +11,6 @@ export const CLASSES = {
 export const IDS = {
   NAV_EXPAND_ICON: "navbar__expand",
   NAV_CLOSE_ICON: "navbar__close",
-  NAV_LINKS: "navbar__primary-navigation"
+  NAV_LINKS: "navbar__primary-navigation",
+  HERO_SECTION: "home"
 }

--- a/src/entities/Navbar/config/DOMSelectors.js
+++ b/src/entities/Navbar/config/DOMSelectors.js
@@ -8,3 +8,4 @@ export const NAV_ANCHORS = `${NAV_UNORDERED_LIST} a`;
 export const NAVBAR_TOGGLE_BUTTON = `button.${CLASSES.TOGGLE_BUTTON}`;
 export const NAV_EXPAND_ICON = `#${IDS.NAV_EXPAND_ICON}`;
 export const NAV_CLOSE_ICON = `#${IDS.NAV_CLOSE_ICON}`;
+export const HERO_SECTION = `#${IDS.HERO_SECTION}`;

--- a/src/entities/Navbar/config/ObserverOptions.js
+++ b/src/entities/Navbar/config/ObserverOptions.js
@@ -10,3 +10,9 @@ export const MAIN_SECTIONS_OPTIONS =
       rootMargin: "-25% 0px -30% 0px",
       threshold: 0.07,
     };
+
+export const HERO_SECTION_OPTIONS = {
+  root: null,
+  rootMargin: '0px',
+  threshold: 0.3
+}

--- a/src/entities/Navbar/index.astro
+++ b/src/entities/Navbar/index.astro
@@ -7,14 +7,18 @@ import Navbar from "./ui/Navbar.astro";
 <script>
   import {
     NAVBAR,
+    CERTIFICATE_LOGO,
+    BRAND_LOGO,
     NAVBAR_TOGGLE_BUTTON,
     NAV_UNORDERED_LIST,
     NAV_EXPAND_ICON,
     NAV_CLOSE_ICON,
     NAV_ANCHORS,
+    HERO_SECTION,
   } from "./config/DOMSelectors";
   import enableNavbarMenuToggle from "./model/enableNavbarMenuToggle";
   import displayActiveSection from "./model/displayActiveSection";
+  import controlNavbarDisplay from "./model/controlNavbarDisplay";
 
   const NAV_MENU_SELECTORS = {
     navbarSelector: NAVBAR,
@@ -23,7 +27,14 @@ import Navbar from "./ui/Navbar.astro";
     navExpandIconSelector: NAV_EXPAND_ICON,
     navCloseIconSelector: NAV_CLOSE_ICON,
   };
+  const NAV_DISPLAY_SELECTORS = {
+    heroSectionSelector: HERO_SECTION,
+    navbarSelector: NAVBAR,
+    certificateLogoSelector: CERTIFICATE_LOGO,
+    brandLogoSelector: BRAND_LOGO,
+  };
 
   enableNavbarMenuToggle(NAV_MENU_SELECTORS);
   displayActiveSection(NAV_ANCHORS);
+  controlNavbarDisplay(NAV_DISPLAY_SELECTORS);
 </script>

--- a/src/entities/Navbar/model/controlNavbarDisplay.js
+++ b/src/entities/Navbar/model/controlNavbarDisplay.js
@@ -1,0 +1,114 @@
+import {
+  getAllDomElements,
+  getDomElement
+} from "../../../shared/utils/pure";
+import { HERO_SECTION_OPTIONS } from "../config/ObserverOptions";
+
+const controlNavbarDisplay = ({
+  heroSectionSelector,
+  navbarSelector,
+  certificateLogoSelector,
+  brandLogoSelector
+}) => {
+  let lastScrollTop, navbarHideTimeout;
+
+  const heroSection = getDomElement(heroSectionSelector);
+  const navbar = getDomElement(navbarSelector);
+  const certificateLogo = getDomElement(certificateLogoSelector);
+  const brandLogo = getDomElement(brandLogoSelector);
+
+  const screenOrientation = window.screen.orientation;
+
+  const setNavbarHideTimeout = () => {
+    clearTimeout(navbarHideTimeout);
+
+    navbarHideTimeout = setTimeout(() => {
+      navbar.setAttribute('data-slide', 'up');
+    }, 2000)
+  }
+
+  const clearNavbarHideTimeout = () => {
+    clearTimeout(navbarHideTimeout);
+  }
+
+  const showHideNavbar = () => {
+    const currentScrollTop =
+      window.pageYOffset || document.documentElement.scrollTop;
+
+    if (currentScrollTop > lastScrollTop) {
+      navbar.setAttribute('data-slide', 'up');
+      clearTimeout(navbarHideTimeout);
+    } else {
+      navbar.setAttribute('data-slide', 'down');
+      clearTimeout(navbarHideTimeout);
+      setNavbarHideTimeout();
+      navbar.addEventListener('mouseenter', clearNavbarHideTimeout);
+    }
+    lastScrollTop = currentScrollTop;
+  }
+
+  const navbarDynamicDisplay = ([entry]) => {
+    if (entry.isIntersecting) {
+      if (window.innerWidth >= 1008) {
+        certificateLogo.setAttribute('data-show', 'true');
+        brandLogo.setAttribute('data-show', 'false');
+      } else {
+        certificateLogo.setAttribute('data-show', 'false');
+        brandLogo.setAttribute('data-show', 'true');
+      }
+      navbar.removeAttribute('data-theme');
+      navbar.setAttribute('data-slide', 'down');
+      clearTimeout(navbarHideTimeout);
+      document.removeEventListener('scroll', showHideNavbar);
+      navbar.removeEventListener('mouseleave', setNavbarHideTimeout);
+    } else if (!entry.isIntersecting) {
+      if (window.innerWidth >= 1008) {
+        navbar.setAttribute('data-theme', 'inverse');
+        certificateLogo.setAttribute('data-show', 'false');
+        brandLogo.setAttribute('data-show', 'true');
+        document.addEventListener('scroll', showHideNavbar);
+        navbar.addEventListener('mouseleave', setNavbarHideTimeout);
+      } else {
+        navbar.setAttribute('data-slide', 'down');
+        certificateLogo.setAttribute('data-show', 'false');
+        brandLogo.setAttribute('data-show', 'true');
+      }
+    }
+  }
+
+  const resetNavbarDynamicDisplay = (
+    heroSectionObserver,
+    heroSection
+  ) => () => {
+    clearNavbarHideTimeout();
+    document.removeEventListener("scroll", showHideNavbar);
+    navbar.removeEventListener("mouseleave", setNavbarHideTimeout);
+    navbar.removeEventListener('mouseenter', clearNavbarHideTimeout);
+    heroSectionObserver.unobserve(heroSection);
+    heroSectionObserver.observe(heroSection);
+  }
+
+  const handleOrientationChange = (heroSectionObserver, heroSection) => {
+    if (!screenOrientation) { // For Safari
+      window.addEventListener(
+        "orientationchange",
+        resetNavbarDynamicDisplay(heroSectionObserver, heroSection)
+      )
+    } else {
+      screenOrientation.addEventListener(
+        "change",
+        resetNavbarDynamicDisplay(heroSectionObserver, heroSection)
+      )
+    }
+  }
+
+  const heroSectionObserver = new IntersectionObserver(
+    navbarDynamicDisplay,
+    HERO_SECTION_OPTIONS
+  )
+
+  heroSectionObserver.observe(heroSection);
+  handleOrientationChange(heroSectionObserver, heroSection);
+}
+
+export default controlNavbarDisplay


### PR DESCRIPTION
Navbar theme is changed based on it's intersection with the hero section.
Navbar is shown when scrolled up, and hidden when scrolled down, as well as hidden automatically after user stops scrolling up for a few seconds. Navbar is continuously displayed when is intersecting the hero section or when the user is hovering on it.
Navbar is always displayed on small screen sizes (bellow 1008px). Navbar will reset the intersection observer and all the other listeners on screen orientation change.